### PR TITLE
Psr Storage

### DIFF
--- a/proposed/psr-storage/Psr/Storage/ExceptionInterface.php
+++ b/proposed/psr-storage/Psr/Storage/ExceptionInterface.php
@@ -1,0 +1,3 @@
+<?php namespace Psr\Storage;
+
+class StorageException extends \Exception {}

--- a/proposed/psr-storage/Psr/Storage/StorageInterface.php
+++ b/proposed/psr-storage/Psr/Storage/StorageInterface.php
@@ -14,10 +14,11 @@ interface StorageInterface
      *
      * @param   string  $key
      * @param   mixed   $value
+     * @param   array   $options
      * @return  null
      * @throws  StorageException
      */
-    public function create($key, $value);
+    public function create($key, $value, $options = []);
 
     /**
      * Reads the value of a stored record by key
@@ -33,10 +34,11 @@ interface StorageInterface
      *
      * @param   string  $key
      * @param   mixed   $value
+     * @param   array   $options
      * @return  null
      * @throws  StorageException
      */
-    public function update($key, $value);
+    public function update($key, $value, $options = []);
 
     /**
      * Deletes an existing record by key

--- a/proposed/psr-storage/Psr/Storage/StorageInterface.php
+++ b/proposed/psr-storage/Psr/Storage/StorageInterface.php
@@ -1,0 +1,50 @@
+<?php namespace Psr\Storage;
+
+/**
+ * Describes a storage interface
+ *
+ * The $key used in this interface must be a string or implement the __toString() method.
+ *
+ * Methods in this interface (except for read()) should return null, or raise a StorageException in case of failure
+ */
+interface StorageInterface
+{
+    /**
+     * Create a new entry in the storage by key and value
+     *
+     * @param   string  $key
+     * @param   mixed   $value
+     * @return  null
+     * @throws  StorageException
+     */
+    public function create($key, $value);
+
+    /**
+     * Reads the value of a stored record by key
+     *
+     * @param   string  $key
+     * @return  mixed
+     * @throws  StorageException
+     */
+    public function read($key);
+
+    /**
+     * Updates an existing record by key and value
+     *
+     * @param   string  $key
+     * @param   mixed   $value
+     * @return  null
+     * @throws  StorageException
+     */
+    public function update($key, $value);
+
+    /**
+     * Deletes an existing record by key
+     *
+     * @param   string  $key
+     * @return  null
+     * @throws  StorageException
+     */
+    public function delete($key);
+
+}

--- a/proposed/psr-storage/README.md
+++ b/proposed/psr-storage/README.md
@@ -26,22 +26,24 @@ in this interface are create, read, update and delete.
  *
  * The $key used in this interface must be a string or implement the __toString() method.
  *
- * The methods create, update and delete in this interface should return null, or raise a StorageException in case of failure
+ * Methods in this interface (except for read()) should return null, or raise a StorageException in case of failure.
+ * A StorageException will also be raised in case the storage system is unreachable.
  */
 interface StorageInterface
 {
     /**
-     * Create a new entry in the storage by key and value
+     * Create a new entry in the storage by key and value or raises a StorageException in case the given key is already used.
      *
      * @param   string  $key
      * @param   mixed   $value
+     * @param   array   $options
      * @return  null
      * @throws  StorageException
      */
-    public function create($key, $value);
+    public function create($key, $value, $options = []);
 
     /**
-     * Reads the value of a stored record by key
+     * Reads the value of a stored record by key or raises a StorageException in case the key does not exist.
      *
      * @param   string  $key
      * @return  mixed
@@ -50,17 +52,18 @@ interface StorageInterface
     public function read($key);
 
     /**
-     * Updates an existing record by key and value
+     * Updates an existing record by key and value.
      *
      * @param   string  $key
      * @param   mixed   $value
+     * @param   array   $options
      * @return  null
      * @throws  StorageException
      */
-    public function update($key, $value);
+    public function update($key, $value, $options = []);
 
     /**
-     * Deletes an existing record by key
+     * Deletes an existing record by key or raises a StorageException in case the key does not exist.
      *
      * @param   string  $key
      * @return  null

--- a/proposed/psr-storage/README.md
+++ b/proposed/psr-storage/README.md
@@ -14,6 +14,8 @@ in this interface are create, read, update and delete.
 
 - All four methods accept a string or an object implementing the `__toString()` method 
   as a key. If an object is passed the implementor must cast it to a string.
+- The create and update methods accept an optional options parameter to support for
+  options like TTL or permissions (on filesystems).
 
 #### Psr\Storage\StorageInterface
 ```php


### PR DESCRIPTION
@stevleibelt 

I've added you as a collaborator to enable you comments on this thread. As this is a fork I was forced to create the pull request for comments. Not an ideal way, but better than in a ZF2 Issue.

I came across that "string or an object implementing the __toString() method" in the PSR LogInterface and liked it. Because these are standards, I think these kind of things should be consistent in all PSR's.

I implemented the `$options` parameter as a generic way to add options like TTL, but not limited to TTL. TTL is primarily something implemented in caching systems, I thought it didn't fit into this StorageInterface as this is a interface for storage systems like Redis, Memcached or even a general filesystem. 

My intention was not to implement a general interface for all kinds of storage as this is impossible in my opinion. Relational databases and NoSQL databases are definitely a special use case and need a separate system from this one, which should be handled by ORM's.

I get your point about checking whether it's a collection, just one item or even null. Therefor I think it would be better to implement the BREAD principle instead or CRUD. This way the read method would only return one item (or null) and the browse method would return an array of items (or an empty array).

The interface would look something like this:
```php
interface StorageInterface
{
    /**
     * Reads returns a list of items based on the criteria in the search array
     *
     * @param   array   $search
     * @param   array   $options
     * @return  array
     * @throws  StorageException
     */
    public function browse($search = [], $options = []);

    /**
     * Reads the value of a stored record by key
     *
     * @param   string  $key
     * @return  mixed
     * @throws  StorageException
     */
    public function read($key);
  
    /**
     * Create a new entry in the storage by key and value
     *
     * @param   string  $key
     * @param   mixed   $value
     * @param   array   $options
     * @return  null
     * @throws  StorageException
     */
    public function add($value, $key = null, $options = []);

    /**
     * Updates an existing record by key and value
     *
     * @param   string  $key
     * @param   mixed   $value
     * @param   array   $options
     * @return  null
     * @throws  StorageException
     */
    public function edit($value, $key, $options = []);

    /**
     * Deletes an existing record by key
     *
     * @param   string  $key
     * @return  null
     * @throws  StorageException
     */
    public function delete($key);

}
```

As for the readMany and readAll methods in your example, in this example they would be combined into the browse method, which will return all items in case no criteria are added. 

In my opinion edit/update should be only per one item. Forcing implementors the implement the ability to update multiple records at once would be too much. As this will be proposed as a PSR standard it should be as simple as possible.

As you can see, I did omit the `$key` on the add method. You made a good point that this interface should not be responsible for creating the actual key. I do think, that it should return the full item on the add method to publish the key to the calling class/method.

I think this standard should not implement a collection. It should not be the responsibility of the storage PSR to define collections. To make it compatible with collections I think on the browse method we should return a Traversable instance. 